### PR TITLE
docs: update README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ These plugins allow you to view and interact with your Spacelift stacks and runs
 
 This monorepo hosts the following plugins:
 
-- **[Spacelift Backend Plugin](./packages/spacelift-io-backend/README.md)**: Handles communication with the Spacelift API and provides data to the frontend.
+- **[Spacelift Backend Plugin](./packages/spacelift-io-backend/README.md)**: Handles communication with the Spacelift API and provides data to the frontend. Published as `@spacelift-io/backstage-integration-backend`.
   - [View README](./packages/spacelift-io-backend/README.md)
-- **[Spacelift Frontend Plugin](./packages/spacelift-io-frontend/README.md)**: Provides the user interface components to display Spacelift information within Backstage.
+- **[Spacelift Frontend Plugin](./packages/spacelift-io-frontend/README.md)**: Provides the user interface components to display Spacelift information within Backstage. Published as `@spacelift-io/backstage-integration-frontend`.
   - [View README](./packages/spacelift-io-frontend/README.md)
 
 ## Overview
@@ -59,6 +59,17 @@ It is the responsibility of the Backstage instance administrator to ensure that 
 
 Contributions are welcome! Please open an issue to discuss potential changes.
 
+## Compatibility
+
+These plugins are compatible with:
+
+| Plugin   | Backstage Compatibility                                                                           |
+| -------- | ------------------------------------------------------------------------------------------------- |
+| Frontend | Requires Backstage `@backstage/core-components` >= 0.17.1, `@backstage/core-plugin-api` >= 1.10.6 |
+| Backend  | Requires Backstage `@backstage/backend-plugin-api` >= 1.3.0                                       |
+
+We recommend using these plugins with Backstage version 1.17.0 or later to ensure full compatibility.
+
 ## License
 
-This project is licensed under the Apache 2.0 License - see the [LICENSE](./LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](./LICENSE) file for details.

--- a/packages/spacelift-io-backend/README.md
+++ b/packages/spacelift-io-backend/README.md
@@ -8,7 +8,7 @@ This backend plugin for Backstage integrates with Spacelift to provide informati
 
    ```bash
    # From your Backstage root directory
-   yarn --cwd packages/backend add @spacelift/backstage-integration-backend
+   yarn --cwd packages/backend add @spacelift-io/backstage-integration-backend
    ```
 
 2. Add the plugin to your backend in `packages/backend/src/index.ts`:
@@ -19,7 +19,7 @@ This backend plugin for Backstage integrates with Spacelift to provide informati
 
    const backend = createBackend();
    // ...
-   backend.add(import('@spacelift/backstage-integration-backend'));
+   backend.add(import('@spacelift-io/backstage-integration-backend'));
    // ...
    await backend.start();
    ```
@@ -37,6 +37,16 @@ spacelift:
 
 Make sure to replace `<your-subdomain>` with your actual Spacelift subdomain.
 The `apiKey` and `apiSecret` should be stored securely, for example, as environment variables.
+
+## Compatibility
+
+This plugin requires:
+
+- `@backstage/backend-plugin-api` >= 1.3.0
+- `@backstage/backend-defaults` >= 0.9.0
+- `@backstage/catalog-client` >= 1.9.1
+
+It is compatible with Backstage 1.17.0 or later.
 
 ## Frontend Plugin
 

--- a/packages/spacelift-io-frontend/README.md
+++ b/packages/spacelift-io-frontend/README.md
@@ -8,14 +8,14 @@ This frontend plugin for Backstage provides a user interface to view and interac
 
    ```bash
    # From your Backstage root directory
-   yarn --cwd packages/app add @spacelift/backstage-integration-frontend
+   yarn --cwd packages/app add @spacelift-io/backstage-integration-frontend
    ```
 
 2. Add the plugin to your `packages/app/src/App.tsx`:
 
    ```tsx
    // packages/app/src/App.tsx
-   import { SpaceliftIoPage } from '@spacelift/backstage-integration-frontend';
+   import { SpaceliftIoPage } from '@spacelift-io/backstage-integration-frontend';
 
    // ...
 
@@ -62,6 +62,16 @@ Make sure to replace `<your-subdomain>` with your actual Spacelift subdomain.
 This frontend plugin relies on the permissions configured for the Spacelift API Key in the backend plugin. It does not implement separate user-level permission checks within the frontend components.
 
 Ensure that your Backstage instance has appropriate general permissions set up to control access to this plugin's pages and functionalities. This is crucial to prevent users from performing actions in Spacelift for which they are not authorized via the configured API key.
+
+## Compatibility
+
+This plugin requires:
+
+- `@backstage/core-components` >= 0.17.1
+- `@backstage/core-plugin-api` >= 1.10.6
+- `@backstage/plugin-catalog-react` >= 1.17.0
+
+It is compatible with Backstage 1.17.0 or later.
 
 ## Backend Plugin
 


### PR DESCRIPTION
Update the docs to use the new npm organization naming.
Fixed inconsistency in the license mentioned in the README