### PR TITLE
chore: bump deprecated node20 GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
Bumps GitHub Actions that were using the deprecated Node.js 20 runtime.

## Changes
- `actions/checkout@v4 → actions/checkout@v7`
- `actions/setup-node@v4 → actions/setup-node@v6`

## Why
Node.js 20 reached EOL in April 2026 and GitHub is deprecating it on Actions runners.
See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

> ⚠️ Actions with potentially breaking changes (custom configs, major API changes) are excluded and need manual review.

🤖 Generated with Claude Code